### PR TITLE
Fixups

### DIFF
--- a/nih-dbus-tool/Makefile.am
+++ b/nih-dbus-tool/Makefile.am
@@ -72,25 +72,25 @@ check_PROGRAMS = \
 test_main_SOURCES = tests/test_main.c main.c
 test_main_CFLAGS = $(AM_CFLAGS) -DTEST
 test_main_LDFLAGS = -static
-test_main_LDADD = ../nih/libnih.la
+test_main_LDADD = ../nih/libnih.la @LIBINTL@
 
 test_symbol_SOURCES = tests/test_symbol.c
 test_symbol_LDFLAGS = -static
 test_symbol_LDADD = \
 	symbol.o \
-	../nih/libnih.la
+	../nih/libnih.la @LIBINTL@
 
 test_indent_SOURCES = tests/test_indent.c
 test_indent_LDFLAGS = -static
 test_indent_LDADD = \
 	indent.o \
-	../nih/libnih.la
+	../nih/libnih.la @LIBINTL@
 
 test_type_SOURCES = tests/test_type.c
 test_type_LDFLAGS = -static
 test_type_LDADD = \
 	type.o indent.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(DBUS_LIBS)
 
 test_marshal_SOURCES = \
@@ -100,7 +100,7 @@ nodist_test_marshal_SOURCES = \
 test_marshal_LDFLAGS = -static
 test_marshal_LDADD = \
 	marshal.o type.o indent.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(DBUS_LIBS)
 
 test_demarshal_SOURCES = \
@@ -110,7 +110,7 @@ nodist_test_demarshal_SOURCES = \
 test_demarshal_LDFLAGS = -static
 test_demarshal_LDADD = \
 	demarshal.o type.o indent.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(DBUS_LIBS)
 
 test_node_SOURCES = tests/test_node.c
@@ -119,7 +119,7 @@ test_node_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -133,7 +133,7 @@ test_interface_LDADD = \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
 	../nih-dbus/libnih-dbus.la \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -147,7 +147,7 @@ test_method_LDADD = \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
 	../nih-dbus/libnih-dbus.la \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -161,7 +161,7 @@ test_signal_LDADD = \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
 	../nih-dbus/libnih-dbus.la \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -175,7 +175,7 @@ test_property_LDADD = \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
 	../nih-dbus/libnih-dbus.la \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -185,7 +185,7 @@ test_argument_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -195,7 +195,7 @@ test_annotation_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -205,7 +205,7 @@ test_parse_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -215,7 +215,7 @@ test_output_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	output.o parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -226,7 +226,7 @@ test_com_netsplit_Nih_Test_object_SOURCES = \
 nodist_test_com_netsplit_Nih_Test_object_SOURCES = \
 	$(com_netsplit_Nih_Test_object_OUTPUTS)
 test_com_netsplit_Nih_Test_object_LDFLAGS = -static
-test_com_netsplit_Nih_Test_object_LDADD = ../nih-dbus/libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_com_netsplit_Nih_Test_object_LDADD = ../nih-dbus/libnih-dbus.la ../nih/libnih.la @LIBINTL@ $(DBUS_LIBS)
 
 test_com_netsplit_Nih_Test_proxy_SOURCES = \
 	tests/test_com.netsplit.Nih.Test_proxy.c \
@@ -235,7 +235,7 @@ nodist_test_com_netsplit_Nih_Test_proxy_SOURCES = \
 	$(com_netsplit_Nih_Test_object_OUTPUTS) \
 	$(com_netsplit_Nih_Test_proxy_OUTPUTS)
 test_com_netsplit_Nih_Test_proxy_LDFLAGS = -static
-test_com_netsplit_Nih_Test_proxy_LDADD = ../nih-dbus/libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_com_netsplit_Nih_Test_proxy_LDADD = ../nih-dbus/libnih-dbus.la ../nih/libnih.la @LIBINTL@ $(DBUS_LIBS)
 
 
 com_netsplit_Nih_Test_object_OUTPUTS = \
@@ -281,7 +281,7 @@ marshal_factory_SOURCES = tests/marshal_factory.c
 marshal_factory_LDFLAGS = -static
 marshal_factory_LDADD = \
 	marshal.o type.o indent.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(DBUS_LIBS)
 
 tests/marshal_code.c: $(builddir)/marshal_factory
@@ -292,7 +292,7 @@ demarshal_factory_SOURCES = tests/demarshal_factory.c
 demarshal_factory_LDFLAGS = -static
 demarshal_factory_LDADD = \
 	demarshal.o type.o indent.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(DBUS_LIBS)
 
 tests/demarshal_code.c: $(builddir)/demarshal_factory
@@ -305,7 +305,7 @@ interface_factory_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -319,7 +319,7 @@ method_factory_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -333,7 +333,7 @@ signal_factory_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 
@@ -347,7 +347,7 @@ property_factory_LDADD = \
 	demarshal.o marshal.o type.o indent.o \
 	parse.o annotation.o argument.o property.o signal.o method.o \
 	interface.o node.o symbol.o \
-	../nih/libnih.la \
+	../nih/libnih.la @LIBINTL@ \
 	$(EXPAT_LIBS) \
 	$(DBUS_LIBS)
 

--- a/nih-dbus/Makefile.am
+++ b/nih-dbus/Makefile.am
@@ -28,7 +28,7 @@ endif
 
 libnih_dbus_la_LIBADD = \
 	../nih/libnih.la \
-	$(DBUS_LIBS) \
+	$(DBUS_LIBS) @LIBINTL@ \
 	-lrt
 
 
@@ -69,31 +69,31 @@ check_PROGRAMS = $(TESTS)
 
 test_dbus_error_SOURCES = tests/test_dbus_error.c
 test_dbus_error_LDFLAGS = -static
-test_dbus_error_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_error_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_connection_SOURCES = tests/test_dbus_connection.c
 test_dbus_connection_LDFLAGS = -static
-test_dbus_connection_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_connection_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_message_SOURCES = tests/test_dbus_message.c
 test_dbus_message_LDFLAGS = -static
-test_dbus_message_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_message_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_object_SOURCES = tests/test_dbus_object.c
 test_dbus_object_LDFLAGS = -static
-test_dbus_object_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_object_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_pending_data_SOURCES = tests/test_dbus_pending_data.c
 test_dbus_pending_data_LDFLAGS = -static
-test_dbus_pending_data_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_pending_data_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_proxy_SOURCES = tests/test_dbus_proxy.c
 test_dbus_proxy_LDFLAGS = -static
-test_dbus_proxy_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_proxy_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 test_dbus_util_SOURCES = tests/test_dbus_util.c
 test_dbus_util_LDFLAGS = -static
-test_dbus_util_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS)
+test_dbus_util_LDADD = libnih-dbus.la ../nih/libnih.la $(DBUS_LIBS) @LIBINTL@
 
 
 .PHONY: tests

--- a/nih/Makefile.am
+++ b/nih/Makefile.am
@@ -33,7 +33,7 @@ if HAVE_VERSION_SCRIPT_ARG
 libnih_la_LDFLAGS += @VERSION_SCRIPT_ARG@=$(srcdir)/libnih.ver
 endif
 
-libnih_la_LIBADD = -lrt
+libnih_la_LIBADD = -lrt @LIBINTL@
 
 
 include_HEADERS = \
@@ -101,71 +101,71 @@ check_PROGRAMS = $(TESTS)
 
 test_alloc_SOURCES = tests/test_alloc.c
 test_alloc_LDFLAGS = -static
-test_alloc_LDADD = libnih.la
+test_alloc_LDADD = libnih.la @LIBINTL@
 
 test_string_SOURCES = tests/test_string.c
 test_string_LDFLAGS = -static
-test_string_LDADD = libnih.la -lutil
+test_string_LDADD = libnih.la @LIBINTL@ -lutil
 
 test_list_SOURCES = tests/test_list.c
 test_list_LDFLAGS = -static
-test_list_LDADD = libnih.la
+test_list_LDADD = libnih.la @LIBINTL@
 
 test_hash_SOURCES = tests/test_hash.c
 test_hash_LDFLAGS = -static
-test_hash_LDADD = libnih.la
+test_hash_LDADD = libnih.la @LIBINTL@
 
 test_tree_SOURCES = tests/test_tree.c
 test_tree_LDFLAGS = -static
-test_tree_LDADD = libnih.la
+test_tree_LDADD = libnih.la @LIBINTL@
 
 test_timer_SOURCES = tests/test_timer.c
 test_timer_LDFLAGS = -static
-test_timer_LDADD = libnih.la
+test_timer_LDADD = libnih.la @LIBINTL@
 
 test_signal_SOURCES = tests/test_signal.c
 test_signal_LDFLAGS = -static
-test_signal_LDADD = libnih.la
+test_signal_LDADD = libnih.la @LIBINTL@
 
 test_child_SOURCES = tests/test_child.c
 test_child_LDFLAGS = -static
-test_child_LDADD = libnih.la
+test_child_LDADD = libnih.la @LIBINTL@
 
 test_io_SOURCES = tests/test_io.c
 test_io_LDFLAGS = -static
-test_io_LDADD = libnih.la
+test_io_LDADD = libnih.la @LIBINTL@
 
 test_file_SOURCES = tests/test_file.c
 test_file_LDFLAGS = -static
-test_file_LDADD = libnih.la
+test_file_LDADD = libnih.la @LIBINTL@
 
 test_watch_SOURCES = tests/test_watch.c
 test_watch_LDFLAGS = -static
-test_watch_LDADD = libnih.la
+test_watch_LDADD = libnih.la @LIBINTL@
 
 test_main_SOURCES = tests/test_main.c
 test_main_LDFLAGS = -static
-test_main_LDADD = libnih.la
+test_main_LDADD = libnih.la @LIBINTL@
 
 test_option_SOURCES = tests/test_option.c
 test_option_LDFLAGS = -static
-test_option_LDADD = libnih.la
+test_option_LDADD = libnih.la @LIBINTL@
 
 test_command_SOURCES = tests/test_command.c
 test_command_LDFLAGS = -static
-test_command_LDADD = libnih.la
+test_command_LDADD = libnih.la @LIBINTL@
 
 test_config_SOURCES = tests/test_config.c
 test_config_LDFLAGS = -static
-test_config_LDADD = libnih.la
+test_config_LDADD = libnih.la @LIBINTL@
 
 test_logging_SOURCES = tests/test_logging.c
 test_logging_LDFLAGS = -static
-test_logging_LDADD = libnih.la
+test_logging_LDADD = libnih.la @LIBINTL@
 
 test_error_SOURCES = tests/test_error.c
 test_error_LDFLAGS = -static
-test_error_LDADD = libnih.la
+test_error_LDADD = libnih.la @LIBINTL@
 
 
 .PHONY: tests

--- a/nih/alloc.c
+++ b/nih/alloc.c
@@ -24,7 +24,6 @@
 #endif /* HAVE_CONFIG_H */
 
 
-#include <malloc.h>
 #include <stdlib.h>
 
 #include <nih/macros.h>

--- a/nih/child.c
+++ b/nih/child.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <signal.h>
 #include <string.h>
 
 #include <nih/macros.h>

--- a/nih/signal.c
+++ b/nih/signal.c
@@ -87,7 +87,9 @@ static const SignalName signal_names[] = {
 	{ SIGSTKFLT, "STKFLT" },
 #endif
 	{ SIGCHLD,   "CHLD"   },
+#ifdef SIGCLD
 	{ SIGCLD,    "CLD"    },
+#endif
 	{ SIGCONT,   "CONT"   },
 	{ SIGSTOP,   "STOP"   },
 	{ SIGTSTP,   "TSTP"   },
@@ -100,11 +102,15 @@ static const SignalName signal_names[] = {
 	{ SIGPROF,   "PROF"   },
 	{ SIGWINCH,  "WINCH"  },
 	{ SIGIO,     "IO"     },
+#ifdef SIGPOLL
 	{ SIGPOLL,   "POLL"   },
+#endif
 #ifdef SIGLOST
 	{ SIGLOST,   "LOST"   },
 #endif
+#ifdef SIGPWR
 	{ SIGPWR,    "PWR"    },
+#endif
 	{ SIGSYS,    "SYS"    },
 #ifdef SIGUNUSED
 	{ SIGUNUSED, "UNUSED" },

--- a/nih/tests/test_alloc.c
+++ b/nih/tests/test_alloc.c
@@ -21,7 +21,6 @@
 
 #include <nih/test.h>
 
-#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/nih/tests/test_child.c
+++ b/nih/tests/test_child.c
@@ -345,7 +345,7 @@ test_poll (void)
 	TEST_FEATURE ("with signal from traced child");
 
 	TEST_CHILD (pid) {
-		assert0 (ptrace (PTRACE_TRACEME, 0, NULL, NULL));
+		assert0 (ptrace (PT_TRACE_ME, 0, NULL, NULL));
 
 		raise (SIGSTOP);
 		raise (SIGCHLD);
@@ -356,7 +356,7 @@ test_poll (void)
 	waitid (P_PID, pid, &siginfo, WSTOPPED);
 
 	assert0 (ptrace (PTRACE_SETOPTIONS, pid, NULL, PTRACE_O_TRACESYSGOOD));
-	assert0 (ptrace (PTRACE_CONT, pid, NULL, SIGCONT));
+	assert0 (ptrace (PT_CONTINUE, pid, NULL, SIGCONT));
 
 	waitid (P_PID, pid, &siginfo, WSTOPPED | WNOWAIT);
 
@@ -379,7 +379,7 @@ test_poll (void)
 	TEST_EQ (last_status, SIGCHLD);
 	TEST_NOT_FREE (watch);
 
-	assert0 (ptrace (PTRACE_DETACH, pid, NULL, 0));
+	assert0 (ptrace (PT_DETACH, pid, NULL, 0));
 
 	kill (pid, SIGTERM);
 	waitid (P_PID, pid, &siginfo, WEXITED);
@@ -399,7 +399,7 @@ test_poll (void)
 	TEST_FEATURE ("with fork by traced child");
 
 	TEST_CHILD (pid) {
-		assert0 (ptrace (PTRACE_TRACEME, 0, NULL, NULL));
+		assert0 (ptrace (PT_TRACE_ME, 0, NULL, NULL));
 
 		raise (SIGSTOP);
 
@@ -415,7 +415,7 @@ test_poll (void)
 
 	assert0 (ptrace (PTRACE_SETOPTIONS, pid, NULL,
 			 PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEFORK));
-	assert0 (ptrace (PTRACE_CONT, pid, NULL, SIGCONT));
+	assert0 (ptrace (PT_CONTINUE, pid, NULL, SIGCONT));
 
 	/* Wait for ptrace to stop the parent (signalling the fork) */
 	waitid (P_PID, pid, &siginfo, WSTOPPED | WNOWAIT);
@@ -456,10 +456,10 @@ test_poll (void)
 	TEST_EQ (last_status, PTRACE_EVENT_FORK);
 	TEST_NOT_FREE (watch);
 
-	assert0 (ptrace (PTRACE_DETACH, child, NULL, SIGCONT));
+	assert0 (ptrace (PT_DETACH, child, NULL, SIGCONT));
 	kill (child, SIGTERM);
 
-	assert0 (ptrace (PTRACE_DETACH, pid, NULL, SIGCONT));
+	assert0 (ptrace (PT_DETACH, pid, NULL, SIGCONT));
 	kill (pid, SIGTERM);
 	waitid (P_PID, pid, &siginfo, WEXITED);
 	nih_free (watch);
@@ -473,7 +473,7 @@ test_poll (void)
 	TEST_FEATURE ("with exec by traced child");
 
 	TEST_CHILD (pid) {
-		assert0 (ptrace (PTRACE_TRACEME, 0, NULL, NULL));
+		assert0 (ptrace (PT_TRACE_ME, 0, NULL, NULL));
 
 		raise (SIGSTOP);
 
@@ -485,7 +485,7 @@ test_poll (void)
 
 	assert0 (ptrace (PTRACE_SETOPTIONS, pid, NULL,
 			 PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXEC));
-	assert0 (ptrace (PTRACE_CONT, pid, NULL, SIGCONT));
+	assert0 (ptrace (PT_CONTINUE, pid, NULL, SIGCONT));
 
 	waitid (P_PID, pid, &siginfo, WSTOPPED | WNOWAIT);
 
@@ -508,7 +508,7 @@ test_poll (void)
 	TEST_EQ (last_status, PTRACE_EVENT_EXEC);
 	TEST_NOT_FREE (watch);
 
-	assert0 (ptrace (PTRACE_DETACH, pid, NULL, SIGCONT));
+	assert0 (ptrace (PT_DETACH, pid, NULL, SIGCONT));
 
 	waitid (P_PID, pid, &siginfo, WEXITED);
 	nih_free (watch);


### PR DESCRIPTION
Libnih fixups:
- fix FTBFS with external LIBINTL
- fix FTBFS when certain signals are not defined
- update to use standard includes
- update to use PT_\* constants
