### PR TITLE
Fallback to lstat, if the non-portable dirent.d_type is not available.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,16 @@
 	!= NULL check for NULL terminated arrays and moves the iteration
 	loop inside an 'if' statement.
 
+2012-12-11  Dmitrijs Ledkovs  <xnox@debian.org>
+
+	* nih/file.c (nih_dir_walk_scan): Fallback to lstat, if the
+	non-portable dirent.d_type is not available (LP: #672643) (Closes:
+	#695604).
+
+2012-12-10  Petr Lautrbach  <plautrba@redhat.com>
+
+	* nih/tests/test_file.c: don't use dirent.d_type (not portable)
+
 2011-08-31  James Hunt  <james.hunt@ubuntu.com>
 
 	* nih-dbus-tool/tests/test_com.netsplit.Nih.Test_object.c

--- a/nih/file.c
+++ b/nih/file.c
@@ -619,6 +619,8 @@ nih_dir_walk_scan (const char    *path,
 	struct dirent  *ent;
 	char          **paths;
 	size_t          npaths;
+	int             isdir;
+	struct stat     statbuf;
 
 	nih_assert (path != NULL);
 
@@ -640,7 +642,15 @@ nih_dir_walk_scan (const char    *path,
 		subpath = NIH_MUST (nih_sprintf (NULL, "%s/%s",
 						 path, ent->d_name));
 
-		if (filter && filter (data, subpath, ent->d_type == DT_DIR))
+		if (ent->d_type == DT_UNKNOWN) {
+			if ( lstat (subpath, &statbuf))
+				isdir = 0;
+			else
+				isdir = S_ISDIR(statbuf.st_mode);
+		} else
+			isdir = ent->d_type == DT_DIR;
+
+		if (filter && filter (data, subpath, isdir))
 			continue;
 
 		NIH_MUST (nih_str_array_addp (&paths, NULL, &npaths, subpath));

--- a/nih/file.c
+++ b/nih/file.c
@@ -643,12 +643,13 @@ nih_dir_walk_scan (const char    *path,
 						 path, ent->d_name));
 
 		if (ent->d_type == DT_UNKNOWN) {
-			if ( lstat (subpath, &statbuf))
-				isdir = 0;
+			if (lstat (subpath, &statbuf))
+				isdir = FALSE;
 			else
 				isdir = S_ISDIR(statbuf.st_mode);
-		} else
+		} else {
 			isdir = ent->d_type == DT_DIR;
+		}
 
 		if (filter && filter (data, subpath, isdir))
 			continue;

--- a/nih/tests/test_file.c
+++ b/nih/tests/test_file.c
@@ -724,6 +724,25 @@ my_filter (void       *data,
 	return FALSE;
 }
 
+/* find only frodo files */
+static int
+my_filter_frodo_file (void       *data,
+	   const char *path,
+	   int         is_dir)
+{
+	char *slash;
+
+	if (is_dir)
+		return FALSE;
+
+	slash = strrchr (path, '/');
+	if (strcmp (slash, "/frodo"))
+		return TRUE;
+
+	return FALSE;
+}
+
+
 static int logger_called = 0;
 
 static int
@@ -902,6 +921,48 @@ test_dir_walk (void)
 		TEST_EQ_STR (v->dirname, dirname);
 		strcpy (filename, dirname);
 		strcat (filename, "/foo");
+		TEST_EQ_STR (v->path, filename);
+
+		nih_free (visited);
+
+				/* Try also inverse filter */
+		TEST_ALLOC_SAFE {
+			visitor_called = 0;
+			visited = nih_list_new (NULL);
+		}
+
+		ret = nih_dir_walk (dirname, my_filter_frodo_file,
+				    my_visitor, NULL, &ret);
+
+		TEST_EQ (ret, 0);
+		TEST_EQ (visitor_called, 4);
+
+		v = (Visited *)visited->next;
+		TEST_EQ (v->data, &ret);
+		TEST_EQ_STR (v->dirname, dirname);
+		strcpy (filename, dirname);
+		strcat (filename, "/bar");
+		TEST_EQ_STR (v->path, filename);
+
+		v = (Visited *)v->entry.next;
+		TEST_EQ (v->data, &ret);
+		TEST_EQ_STR (v->dirname, dirname);
+		strcpy (filename, dirname);
+		strcat (filename, "/bar/frodo");
+		TEST_EQ_STR (v->path, filename);
+
+		v = (Visited *)v->entry.next;
+		TEST_EQ (v->data, &ret);
+		TEST_EQ_STR (v->dirname, dirname);
+		strcpy (filename, dirname);
+		strcat (filename, "/baz");
+		TEST_EQ_STR (v->path, filename);
+
+		v = (Visited *)v->entry.next;
+		TEST_EQ (v->data, &ret);
+		TEST_EQ_STR (v->dirname, dirname);
+		strcpy (filename, dirname);
+		strcat (filename, "/frodo");
 		TEST_EQ_STR (v->path, filename);
 
 		nih_free (visited);


### PR DESCRIPTION
Fixes running libnih & upstart on XFS filesystem (and others that don't implement dirent.d_type)

Bug-Debian: http://bugs.debian.org/695604
Bug-Ubuntu: https://bugs.launchpad.net/bugs/672643
