### PR TITLE
nih/logging.c: use our own __nih_abort_msg rather than the (e)glibc symbol

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,12 @@
 	!= NULL check for NULL terminated arrays and moves the iteration
 	loop inside an 'if' statement.
 
+2012-10-25  James Hunt  <james.hunt@ubuntu.com>
+
+	* nih/logging.c: Use our own __nih_abort_msg rather than the
+	(e)glibc private symbol __abort_msg to avoid upgrade issues (LP: #997359).
+	* nih/tests/test_logging.c: Update tests for __nih_abort_msg.
+
 2011-08-31  James Hunt  <james.hunt@ubuntu.com>
 
 	* nih-dbus-tool/tests/test_com.netsplit.Nih.Test_object.c

--- a/nih/logging.c
+++ b/nih/logging.c
@@ -39,11 +39,11 @@
 
 
 /**
- * __abort_msg:
+ * __nih_abort_msg:
  *
- * A glibc variable that keeps the assertion message in the core dump.
+ * A variable that keeps the assertion message in the core dump.
  **/
-extern char *__abort_msg __attribute__ ((weak));
+char *__nih_abort_msg;
 
 /**
  * logger:
@@ -114,19 +114,19 @@ nih_log_set_priority (NihLogLevel new_priority)
  * nih_log_abort_message:
  * @message: message to be logged.
  *
- * Save @message in the glibc __abort_msg variable so it can be retrieved
+ * Save @message in the __nih_abort_msg variable so it can be retrieved
  * by debuggers if we should crash at this point.
  **/
 static void
 nih_log_abort_message (const char *message)
 {
-	if (! &__abort_msg)
+	if (! &__nih_abort_msg)
 		return;
 
-	if (__abort_msg)
-		nih_discard (__abort_msg);
+	if (__nih_abort_msg)
+		nih_discard (__nih_abort_msg);
 
-	__abort_msg = NIH_MUST (nih_strdup (NULL, message));
+	__nih_abort_msg = NIH_MUST (nih_strdup (NULL, message));
 }
 
 /**

--- a/nih/tests/test_logging.c
+++ b/nih/tests/test_logging.c
@@ -31,7 +31,7 @@
 #include <nih/main.h>
 
 
-extern char *__abort_msg __attribute__ ((weak));
+extern char *__nih_abort_msg;
 
 static NihLogLevel last_priority = NIH_LOG_UNKNOWN;
 static char *      last_message = NULL;
@@ -156,13 +156,13 @@ test_log_message (void)
 	}
 
 
-	/* Check that a fatal message is also stored in the glibc __abort_msg
+	/* Check that a fatal message is also stored in the __nih_abort_msg
 	 * variable.
 	 */
-	if (&__abort_msg) {
+	if (&__nih_abort_msg) {
 		TEST_FEATURE ("with fatal message");
 		TEST_ALLOC_FAIL {
-			__abort_msg = NULL;
+			__nih_abort_msg = NULL;
 			last_priority = NIH_LOG_UNKNOWN;
 			last_message = NULL;
 
@@ -174,16 +174,16 @@ test_log_message (void)
 			TEST_EQ (last_priority, NIH_LOG_FATAL);
 			TEST_EQ_STR (last_message, "message with some 20 formatting");
 
-			TEST_NE_P (__abort_msg, NULL);
-			TEST_ALLOC_PARENT (__abort_msg, NULL);
-			TEST_EQ_STR (__abort_msg, "message with some 20 formatting");
+			TEST_NE_P (__nih_abort_msg, NULL);
+			TEST_ALLOC_PARENT (__nih_abort_msg, NULL);
+			TEST_EQ_STR (__nih_abort_msg, "message with some 20 formatting");
 
 			free (last_message);
 		}
 
 
 		/* Check that a fatal message can safely overwrite one already stored
-		 * in the glibc __abort_msg variable.
+		 * in the __nih_abort_msg variable.
 		 */
 		TEST_FEATURE ("with second fatal message");
 		TEST_ALLOC_FAIL {
@@ -191,7 +191,7 @@ test_log_message (void)
 				msg = nih_strdup (NULL, "test");
 			}
 
-			__abort_msg = msg;
+			__nih_abort_msg = msg;
 			TEST_FREE_TAG (msg);
 
 			last_priority = NIH_LOG_UNKNOWN;
@@ -207,14 +207,14 @@ test_log_message (void)
 
 			TEST_FREE (msg);
 
-			TEST_NE_P (__abort_msg, NULL);
-			TEST_ALLOC_PARENT (__abort_msg, NULL);
-			TEST_EQ_STR (__abort_msg, "message with some 20 formatting");
+			TEST_NE_P (__nih_abort_msg, NULL);
+			TEST_ALLOC_PARENT (__nih_abort_msg, NULL);
+			TEST_EQ_STR (__nih_abort_msg, "message with some 20 formatting");
 
 			free (last_message);
 		}
 	} else {
-		printf ("SKIP: __abort_msg not available\n");
+		printf ("SKIP: __nih_abort_msg not available\n");
 	}
 
 


### PR DESCRIPTION
1) __abort_msg is not available in all libc's
2) when it is available, it creates a tight dependancy between libnih and (e)glibc, requiring libnih to be recompiled against each (e)glibc upload
3) equivalent functionality can be provided by our own implementation on abort_msg.
4) apport in ubuntu has been modifyied to look up crash message from __nih_abort_msg in additional to __abort_msg, thus decoupling (e)glibc from libnih

This patch creates our own __nih_abort_msg. There are other alternatives that could be implemented (e.g. add a conditional to offer using __abort_msg (if available) and select/fallback to __nih_abort_msg. Let me know your thoughts on this.
- nih/logging.c: Use our own __nih_abort_msg rather than the (e)glibc private symbol __abort_msg to avoid upgrade issues (LP: #997359).
- nih/tests/test_logging.c: Update tests for __nih_abort_msg.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/997359
