### PR TITLE
Drop including (unused) malloc.h

### DIFF
--- a/nih/alloc.c
+++ b/nih/alloc.c
@@ -24,7 +24,6 @@
 #endif /* HAVE_CONFIG_H */
 
 
-#include <malloc.h>
 #include <stdlib.h>
 
 #include <nih/macros.h>

--- a/nih/tests/test_alloc.c
+++ b/nih/tests/test_alloc.c
@@ -21,7 +21,6 @@
 
 #include <nih/test.h>
 
-#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
malloc.h used to define malloc hooks API, which have been deprecated
and marked volatile in (e)glibc 2.14. Malloc hooks, nor other special
facilities defined in malloc.h, appear to not be used, thus this
include is redundant.

http://sourceware.org/ml/libc-alpha/2011-05/msg00103.html
