### PR TITLE
Add LTLIBINTL to libnih.la

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = m4 intl nih nih-dbus nih-dbus-tool po
+SUBDIRS = m4 nih nih-dbus nih-dbus-tool po
 
 EXTRA_DIST = HACKING
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,8 +15,8 @@ AM_MAINTAINER_MODE([enable])
 LT_PREREQ(2.2.4)
 LT_INIT
 
-AM_GNU_GETTEXT_VERSION([0.17])
-AM_GNU_GETTEXT()
+AM_GNU_GETTEXT_VERSION([0.18.3])
+AM_GNU_GETTEXT([external])
 
 # Checks for programs.
 AC_PROG_CC
@@ -58,7 +58,7 @@ AS_IF([test "$cross_compiling" = "yes"],
 	      AC_SUBST([NIH_DBUS_TOOL], ["\${top_builddir}/nih-dbus-tool/nih-dbus-tool"])])],
       [AC_SUBST([NIH_DBUS_TOOL], ["\${top_builddir}/nih-dbus-tool/nih-dbus-tool"])])
 
-AC_CONFIG_FILES([ Makefile m4/Makefile intl/Makefile
+AC_CONFIG_FILES([ Makefile m4/Makefile
 		  nih/Makefile nih/libnih.pc
 		  nih-dbus/Makefile nih-dbus/libnih-dbus.pc
 		  nih-dbus-tool/Makefile

--- a/nih/Makefile.am
+++ b/nih/Makefile.am
@@ -33,7 +33,7 @@ if HAVE_VERSION_SCRIPT_ARG
 libnih_la_LDFLAGS += @VERSION_SCRIPT_ARG@=$(srcdir)/libnih.ver
 endif
 
-libnih_la_LIBADD = -lrt
+libnih_la_LIBADD = -lrt $(LTLIBINTL)
 
 
 include_HEADERS = \


### PR DESCRIPTION
In case intl support is not part of libc, and thus local or external
libraries are needed at link time to gain NLS.
