### PR TITLE
Make test.h use TAP formatted output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,8 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_GNU_SOURCE
 
 AM_INIT_AUTOMAKE([1.11 gnu nostdinc check-news color-tests silent-rules])
+AC_REQUIRE_AUX_FILE([tap-driver.sh])
+AC_PROG_AWK
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([enable])
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_GNU_SOURCE
 AM_INIT_AUTOMAKE([1.11 gnu nostdinc check-news color-tests silent-rules])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 AC_PROG_AWK
+AC_DEFINE([NIH_TAP_OUTPUT], [1], [Do not abort on test failure])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([enable])
 

--- a/nih-dbus-tool/Makefile.am
+++ b/nih-dbus-tool/Makefile.am
@@ -41,6 +41,7 @@ nih_dbus_tool_LDADD = \
 	$(DBUS_LIBS)
 
 
+LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 TESTS = \
 	test_main \
 	test_symbol \

--- a/nih-dbus/Makefile.am
+++ b/nih-dbus/Makefile.am
@@ -56,6 +56,7 @@ pkgconfig_DATA = libnih-dbus.pc
 EXTRA_DIST = libnih-dbus.ver libnih-dbus.supp libnih-dbus.pc.in
 
 
+LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 TESTS = \
 	test_dbus_error \
 	test_dbus_connection \

--- a/nih/Makefile.am
+++ b/nih/Makefile.am
@@ -78,6 +78,7 @@ pkgconfig_DATA = libnih.pc
 EXTRA_DIST = libnih.ver libnih.supp libnih.pc.in
 
 
+LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 TESTS = \
 	test_alloc \
 	test_string \

--- a/nih/test_output.h
+++ b/nih/test_output.h
@@ -26,6 +26,68 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
+#include <sys/file.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <nih/macros.h>
+
+static char TEST_BLOCK_NAME[PATH_MAX] = "" ;
+static char TEST_FEATURE_NAME[PATH_MAX] = "" ;
+static int TEST_COUNT = 0;
+static int TEST_PLAN_CALLED = FALSE;
+static char TEST_EXIT_LOCK[PATH_MAX] = "";
+static inline void print_last ( void );
+
+/**
+ * TEST_PLAN:
+ * @_num: number of planned tests to run
+ *
+ * Output the number of tests expected to be executed. This can be
+ * declared only once, at the beginning or the end of the test output.
+ *
+ * If not called, an exit plan with total number of executed tests
+ * will be printed.
+ **/
+#define TEST_PLAN(_num) \
+	printf ("1..%d\n", _num); TEST_PLAN_CALLED = TRUE
+
+/**
+ * TEST_PLAN_END:
+ *
+ * Output the number of tests that got executed.
+ **/
+#define TEST_PLAN_END() \
+	if (! TEST_PLAN_CALLED) printf ("1..%d\n", TEST_COUNT)
+
+/**
+ * TEST_PRINT_RESULT(_ok)
+ * @_ok: test result
+ *
+ * Output result of last run function if any.
+ **/
+#define TEST_PRINT_RESULT(_ok)						\
+	if (TEST_COUNT == 0) {						\
+		sprintf (TEST_EXIT_LOCK, "%d", getpid() );		\
+		setenv ("TEST_EXIT_LOCK", TEST_EXIT_LOCK, 1);		\
+		atexit (print_last);					\
+	}								\
+        if (TEST_COUNT > 0) printf ("%s %d - %s %s\n", _ok ? "ok" : "not ok", TEST_COUNT, TEST_BLOCK_NAME, TEST_FEATURE_NAME)
+
+/**
+ * print_last:
+ *
+ * atexit handler to print the last test result, and exit plan if needed.
+ **/
+static inline void
+print_last ( void )
+{
+	if ( atoi (getenv ("TEST_EXIT_LOCK")) == getpid ()) {
+		TEST_PRINT_RESULT (TRUE);
+		TEST_PLAN_END();
+	}
+}
 
 
 /**
@@ -35,8 +97,7 @@
  * Output a message indicating that a group of tests testing @_name are
  * being performed.
  **/
-#define TEST_GROUP(_name) \
-	printf ("Testing %s\n", _name)
+#define TEST_GROUP(_name) TEST_PRINT_RESULT (TRUE); TEST_COUNT++; strcpy(TEST_BLOCK_NAME, _name); strcpy(TEST_FEATURE_NAME, "")
 
 /**
  * TEST_FUNCTION:
@@ -45,8 +106,7 @@
  * Output a message indicating that tests of the function named @_func are
  * being performed.
  **/
-#define TEST_FUNCTION(_func) \
-	printf ("Testing %s()\n", _func)
+#define TEST_FUNCTION(_func) TEST_PRINT_RESULT (TRUE); TEST_COUNT++; strcpy(TEST_BLOCK_NAME, _func); strcat(TEST_BLOCK_NAME, "()"); strcpy(TEST_FEATURE_NAME, "")
 
 /**
  * TEST_FUNCTION_FEATURE:
@@ -56,8 +116,7 @@
  * Output a message indicating that tests of the function named @_func are
  * being performed, specifically of the @_feat feature.
  **/
-#define TEST_FUNCTION_FEATURE(_func, _feat)			\
-	printf ("Testing %s() %s\n", _func, _feat)
+#define TEST_FUNCTION_FEATURE(_func, _feat) TEST_GROUP(_func##_feat)
 
 /**
  * TEST_FEATURE:
@@ -66,8 +125,7 @@
  * Output a message indicating that a sub-test of a function or
  * group is being performed, specifically the feature named _feat.
  **/
-#define TEST_FEATURE(_feat) \
-	printf ("...%s\n", _feat);
+#define TEST_FEATURE(_feat) TEST_PRINT_RESULT (TRUE); TEST_COUNT++; strcpy(TEST_FEATURE_NAME, _feat)
 
 /**
  * TEST_FAILED:
@@ -76,11 +134,19 @@
  * Output a formatted message indicating that a test has failed, including
  * the file, line number and function where the failure happened.
  **/
-#define TEST_FAILED(_fmt, ...) \
-	do { \
-		printf ("BAD: " _fmt "\n\tat %s:%d (%s).\n", \
+#ifdef TEST_TAP_BAIL_ON_FAIL
+#define TEST_BAIL() printf ("Bail out!\n"); abort ()
+#else
+#define TEST_BAIL() {}
+#endif
+
+#define TEST_FAILED(_fmt, ...)					       \
+	do {							       \
+		if (++TEST_COUNT)				       \
+			TEST_PRINT_RESULT(FALSE);		       \
+		printf (" BAD: " _fmt "\n\tat %s:%d (%s).\n",		\
 			##__VA_ARGS__, __FILE__, __LINE__, __FUNCTION__); \
-		abort (); \
+		TEST_BAIL();						\
 	} while (0)
 
 #endif /* NIH_TEST_OUTPUT_H */

--- a/nih/test_output.h
+++ b/nih/test_output.h
@@ -26,11 +26,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+#include <linux/limits.h>
 
 #include <nih/macros.h>
 
-static char *TEST_NAME=NULL;
+static char TEST_NAME[PATH_MAX]="";
 static size_t TEST_COUNT = 0;
 static int TEST_PLAN_CALLED = FALSE;
 
@@ -82,7 +84,7 @@ void print_last ( void )
 void
 TEST_PRINT_RESULT(const char * ok)
 {		
-	if (TEST_NAME) {
+	if (strlen(TEST_NAME) > 0) {
 		printf ("%s %zu - %s\n", ok, TEST_COUNT, TEST_NAME);
 		return;
 	}
@@ -119,7 +121,7 @@ print_last ( void )
  * Output a message indicating that a group of tests testing @_name are
  * being performed.
  **/
-#define TEST_START(_name) TEST_PRINT_OK(); TEST_NAME=_name; TEST_COUNT++;
+#define TEST_START(_name) TEST_PRINT_OK(); strncpy(TEST_NAME, _name, PATH_MAX-1); TEST_COUNT++;
 
 #ifdef NIH_TAP_OUTPUT
 #define TEST_FAILED_ABORT() {}
@@ -136,7 +138,7 @@ print_last ( void )
  **/
 #define TEST_FAILED(_fmt, ...)						\
 	do {								\
-		TEST_PRINT_BAD(); TEST_NAME=NULL;			\
+		TEST_PRINT_BAD(); strcpy(TEST_NAME, "");		\
 		printf ("\t" _fmt "\n\tat %s:%d (%s).\n", ##__VA_ARGS__, __FILE__, __LINE__, __FUNCTION__); \
 		TEST_FAILED_ABORT ();					\
 	} while (0)

--- a/nih/test_output.h
+++ b/nih/test_output.h
@@ -121,6 +121,12 @@ print_last ( void )
  **/
 #define TEST_START(_name) TEST_PRINT_OK(); TEST_NAME=_name; TEST_COUNT++;
 
+#ifdef NIH_TAP_OUTPUT
+#define TEST_FAILED_ABORT() {}
+#else
+#define TEST_FAILED_ABORT() abort ()
+#endif
+
 /**
  * TEST_FAILED:
  * @_fmt: format string.
@@ -132,6 +138,7 @@ print_last ( void )
 	do {								\
 		TEST_PRINT_BAD(); TEST_NAME=NULL;			\
 		printf ("\t" _fmt "\n\tat %s:%d (%s).\n", ##__VA_ARGS__, __FILE__, __LINE__, __FUNCTION__); \
+		TEST_FAILED_ABORT ();					\
 	} while (0)
 
 #define TEST_GROUP TEST_START


### PR DESCRIPTION
This branch changes output:

```
    Testing nih_main_write_pidfile()
    ...with successful write
    ...with overwrite of existing pid
    ...with failure to write to temporary file
```

To:

```
ok 21 - nih_main_write_pidfile() 
ok 22 - nih_main_write_pidfile() with successful write
ok 23 - nih_main_write_pidfile() with overwrite of existing pid
ok 24 - nih_main_write_pidfile() with failure to write to temporary file
```

Which is in TAP format (Test Anything Protocol).

This results in automake build logs change from:

```
...
PASS: test_command
PASS: test_config
PASS: test_logging
PASS: test_error
...
============================================================================
Testsuite summary for libnih 1.0.4
============================================================================
# TOTAL: 17
# PASS:  17
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

To:

```
PASS: test_error 1 - nih_error_raise()
PASS: test_error 2 - nih_error_raise_printf()
PASS: test_error 3 - nih_error_raise_system()
PASS: test_error 4 - nih_error_raise_no_memory()
PASS: test_error 5 - nih_error_raise_error()
PASS: test_error 6 - nih_error_raise_error() with no current error
PASS: test_error 7 - nih_error_raise_error() with unhandled error
PASS: test_error 8 - nih_return_error()
PASS: test_error 9 - nih_return_system_error()
PASS: test_error 10 - nih_return_no_memory_error()
PASS: test_error 11 - nih_error_steal()
PASS: test_error 12 - nih_error_steal() with same context
PASS: test_error 13 - nih_error_steal() with different contexts
PASS: test_error 14 - nih_error_push_context()
PASS: test_error 15 - nih_error_pop_context()
PASS: test_error 16 - nih_error_pop_context() with unhandled error in context
PASS: test_error 17 - nih_error_pop_context() with unhandled error beneath context
make[3]: Entering directory `/home/xnox/canonical/libnih/libnih/nih'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/home/xnox/canonical/libnih/libnih/nih'
============================================================================
Testsuite summary for libnih 1.0.4
============================================================================
# TOTAL: 839
# PASS:  839
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Which is a more accurate and useful build-log output.
Furthermore it will enable: skipping tests, marking them expected fail, marking them TODO (unimplemented features), whilst accurately reporting each one of them.

There is no break in testing API and this implementation works across all libnih tests. There is no dependency on executing the test-suite under the TAP runner.

There is one change of behaviour: instead of aborting (bailing) on test failure, a FAIL is reported and the individual test binary will "keep going". I believe this is acceptable as the overall build will fail and is accurately reported. I added a define "TEST_TAP_BAIL_ON_FAIL" which will report a TAP "bail" command and abort as it was done previously. In case one wants previous behaviour.
