### PR TITLE
Enable automake's subdif-objects option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_GNU_SOURCE
 
-AM_INIT_AUTOMAKE([1.11 gnu nostdinc check-news color-tests silent-rules])
+AM_INIT_AUTOMAKE([1.11 gnu nostdinc check-news color-tests silent-rules subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([enable])
 


### PR DESCRIPTION
automake 2.0 will enable subdir-objects by default.
1.14 now issues warnings when sources are used from subdirectories, yet subdir-objects option is not used.
libnih compiles with and without this option. with this option enabled, no warnings are displayed for each
test_foo_SOURCES = tests/test_foo.c
and the test_foo.o is placed in tests/test_foo.o instead of ./test_foo.o
